### PR TITLE
Modified plugin parameter wsdlFile to accept folders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,6 +207,9 @@ dependencies {
         exclude group: 'org.codehaus.groovy'
     }
     testCompile 'commons-io:commons-io:2.2'
+    compile group: 'org.codehaus.gpars', name: 'gpars', version: '1.2.1'
+    compile 'org.codehaus.jsr166-mirror:jsr166y:1.7.0'
+    compile 'org.codehaus.jsr166-mirror:extra166y:1.7.0'
 }
 
 repositories {

--- a/src/main/groovy/com/intershop/gradle/wsdl/tasks/axis1/WSDL2Java.groovy
+++ b/src/main/groovy/com/intershop/gradle/wsdl/tasks/axis1/WSDL2Java.groovy
@@ -245,12 +245,35 @@ class WSDL2Java extends AbstractWSDL2Java {
     File outputDirectory
 
 
+    List<JavaExecHandleBuilder> prepareExec()
+    {
+        File file = getWsdlFile()
+        List<JavaExecHandleBuilder> list = new ArrayList<JavaExecHandleBuilder>()
+
+        if (file.isDirectory())
+        {
+            file.eachFile() { fileItem ->
+
+                JavaExecHandleBuilder exechandler = generateWsdl(fileItem)
+                list.add(exechandler)
+            }
+        }
+        else
+        {
+            JavaExecHandleBuilder exechandler = generateWsdl(file)
+            list.add(exechandler)
+        }
+        return list
+    }
+
+
     /**
      * Prepares the JavaExecHandlerBuilder for the task.
      *
      * @return JavaExecHandleBuilder
      */
-    JavaExecHandleBuilder prepareExec() {
+        JavaExecHandleBuilder generateWsdl(File file) {
+//    JavaExecHandleBuilder prepareExec() {
 
         JavaExecHandleBuilder javaExec = new JavaExecHandleBuilder(getFileResolver())
         getJavaOptions().copyTo(javaExec)
@@ -260,6 +283,7 @@ class WSDL2Java extends AbstractWSDL2Java {
         List<String> args = []
 
         addAttribute(args, getOutputDirectory().absolutePath, '--output')
+
 
         addFlag(args, getNoImports(), '--noImports')
         addAttribute(args, Integer.toString(getTimeout()), '--timeout')
@@ -308,7 +332,8 @@ class WSDL2Java extends AbstractWSDL2Java {
             args << it
         }
 
-        args << wsdlFile.toString()
+        args << file.toString()
+//        args << fileItem.toString()
 
         return javaExec
                 .setClasspath(axis1CodegenConfiguration)

--- a/src/main/groovy/com/intershop/gradle/wsdl/tasks/axis2/WSDL2Java.groovy
+++ b/src/main/groovy/com/intershop/gradle/wsdl/tasks/axis2/WSDL2Java.groovy
@@ -182,12 +182,35 @@ class WSDL2Java extends AbstractWSDL2Java {
     @OutputDirectory
     File  outputDirectory
 
+    List<JavaExecHandleBuilder> prepareExec()
+    {
+       File file = getWsdlFile()
+       List<JavaExecHandleBuilder> list = new ArrayList<JavaExecHandleBuilder>()
+
+        if (file.isDirectory())
+        {
+            file.eachFile() { fileItem ->
+
+                JavaExecHandleBuilder exechandler = generateWsdl(fileItem)
+                list.add(exechandler)
+            }
+        }
+        else
+        {
+            JavaExecHandleBuilder exechandler = generateWsdl(file)
+            list.add(exechandler)
+        }
+        return list
+    }
+
+
+
     /**
      * Prepares the JavaExecHandlerBuilder for the task.
      *
      * @return JavaExecHandleBuilder
      */
-    JavaExecHandleBuilder prepareExec() {
+        JavaExecHandleBuilder generateWsdl(File file) {
         JavaExecHandleBuilder javaExec = new JavaExecHandleBuilder(getFileResolver())
         getJavaOptions().copyTo(javaExec)
 
@@ -195,8 +218,9 @@ class WSDL2Java extends AbstractWSDL2Java {
 
         List<String> args = []
 
-        addAttribute(args, getWsdlFile().absolutePath, '-uri')
-        addAttribute(args, 'java', '--language')
+        addAttribute(args, file.getAbsolutePath(), '-uri')
+
+            addAttribute(args, 'java', '--language')
         addAttribute(args, getPackageName(), '--package')
 
         addFlag(args, getAsync(), '--async')
@@ -263,3 +287,4 @@ class WSDL2Java extends AbstractWSDL2Java {
     }
 
 }
+

--- a/src/test/groovy/com/intershop/gradle/wsdl/Axis1IntegrationSpec.groovy
+++ b/src/test/groovy/com/intershop/gradle/wsdl/Axis1IntegrationSpec.groovy
@@ -47,6 +47,9 @@ class Axis1IntegrationSpec extends AbstractIntegrationSpec {
                 compile 'org.apache.axis:axis:1.4'
                 compile 'org.apache.axis:axis-jaxrpc:1.4'
                 compile 'javax.xml:jaxrpc-api:1.1'
+                compile group: 'org.codehaus.gpars', name: 'gpars', version: '1.2.1'
+                compile 'org.codehaus.jsr166-mirror:jsr166y:1.7.0'
+                compile 'org.codehaus.jsr166-mirror:extra166y:1.7.0'
             }
         """.stripIndent()
 
@@ -274,4 +277,117 @@ class Axis1IntegrationSpec extends AbstractIntegrationSpec {
         where:
         gradleVersion << supportedGradleVersions
     }
+
+    def 'Test directory as wsdl entry parameter'() {
+        given:
+        copyResources('axis1/addressbook/AddressBook.wsdl', 'staticfiles/wsdl/AddressBook.wsdl')
+
+        buildFile << """
+            plugins {
+                id 'java'
+                id 'com.intershop.gradle.wsdl'
+            }
+            
+            wsdl {
+                axis1 {
+                    addressBook {
+                        wsdlFile = file('staticfiles/wsdl/AddressBook.wsdl')
+                    }
+                }
+            }
+            
+            tasks.withType(com.intershop.gradle.wsdl.tasks.axis1.WSDL2Java) {
+                javaOptions.jvmArgs += ["-XX:-UseSerialGC"]  
+                
+                javaOptions.systemProperty 'http.proxyHost', 'test.host.com'
+                javaOptions.systemProperty 'http.proxyPort', '8081'
+                javaOptions.systemProperty 'https.proxyHost', 'test.host.com' 
+                javaOptions.systemProperty 'https.proxyPort', '4081'
+            }
+            
+            repositories {
+                jcenter()
+            }
+
+            dependencies {
+                compile 'org.apache.axis:axis:1.4'
+                compile 'org.apache.axis:axis-jaxrpc:1.4'
+                compile 'javax.xml:jaxrpc-api:1.1'
+            }
+        """.stripIndent()
+
+        when:
+        List<String> args = ['compileJava', '-s', '-i', '--configure-on-demand', '--parallel', '--max-workers=4']
+
+        def result = getPreparedGradleRunner()
+                .withArguments(args)
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then:
+        result.task(':axis1Wsdl2javaAddressBook').outcome == SUCCESS
+        result.task(':compileJava').outcome == SUCCESS
+        result.output.contains('-Dhttp.proxyHost=test.host.com')
+        result.output.contains('-Dhttp.proxyPort=8081')
+        result.output.contains('-Dhttps.proxyHost=test.host.com')
+        result.output.contains('-Dhttps.proxyPort=4081')
+
+        where:
+        gradleVersion << supportedGradleVersions
+    }
+
+    def 'Test generation with multiple files'() {
+        given:
+        copyResources('axis2/multiple-files/StockQuoteServiceOne.wsdl', 'staticfiles/wsdl/StockQuoteServiceOne.wsdl')
+        copyResources('axis2/multiple-files/StockQuoteServiceTwo.wsdl', 'staticfiles/wsdl/StockQuoteServiceTwo.wsdl')
+
+        buildFile << """
+            plugins {
+                id 'java'
+                id 'com.intershop.gradle.wsdl'
+            }
+            
+            wsdl {
+                axis1 {
+                    addressBook {
+                        wsdlFile = file('staticfiles/wsdl/')
+                    }
+                }
+            }
+            
+            repositories {
+                jcenter()
+            }
+
+            dependencies {
+                compile 'org.apache.axis:axis:1.4'
+                compile 'org.apache.axis:axis-jaxrpc:1.4'
+                compile 'javax.xml:jaxrpc-api:1.1'
+            }
+        """.stripIndent()
+
+        when:
+        List<String> args = ['compileJava', '-s', '-i', '--configure-on-demand', '--parallel', '--max-workers=4']
+
+        def result = getPreparedGradleRunner()
+                .withArguments(args)
+                .withGradleVersion(gradleVersion)
+                .build()
+
+        then:
+        result.task(':axis1Wsdl2javaAddressBook').outcome == SUCCESS
+        result.task(':compileJava').outcome == SUCCESS
+
+        List<String> files = new ArrayList(Arrays.asList('build/generated/wsdl2java/axis1/addressBook/samples/quickstart/StockQuoteServiceOne.java',
+                'build/generated/wsdl2java/axis1/addressBook/samples/quickstart/StockQuoteServiceOneLocator.java',
+                'build/generated/wsdl2java/axis1/addressBook/samples/quickstart/StockQuoteServicePortType.java',
+                'build/generated/wsdl2java/axis1/addressBook/samples/quickstart/StockQuoteServiceSOAP11BindingStub.java',
+                'build/generated/wsdl2java/axis1/addressBook/samples/quickstart/StockQuoteServiceTwo.java',
+                'build/generated/wsdl2java/axis1/addressBook/samples/quickstart/StockQuoteServiceTwoLocator.java'))
+        files.forEach{file -> assert (new File(testProjectDir, file)).exists()}
+
+        where:
+        gradleVersion << supportedGradleVersions
+    }
+
 }

--- a/src/test/resources/axis1/multiple-files/StockQuoteServiceOne.wsdl
+++ b/src/test/resources/axis1/multiple-files/StockQuoteServiceOne.wsdl
@@ -1,0 +1,43 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements. See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership. The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<wsdl:definitions xmlns:axis2="http://quickstart.samples/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:ns="http://quickstart.samples/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://quickstart.samples/"><wsdl:types><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://quickstart.samples/xsd">
+<xs:element name="getPrice">
+<xs:complexType>
+<xs:sequence>
+<xs:element name="symbol" nillable="true" type="xs:string" />
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+<xs:element name="getPriceResponse">
+<xs:complexType>
+<xs:sequence>
+<xs:element name="return" nillable="true" type="xs:double" />
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+<xs:element name="update">
+<xs:complexType>
+<xs:sequence>
+<xs:element name="symbol" nillable="true" type="xs:string" />
+<xs:element name="price" nillable="true" type="xs:double" />
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+</xs:schema></wsdl:types><wsdl:message name="getPriceMessage"><wsdl:part name="part1" element="ns:getPrice" /></wsdl:message><wsdl:message name="getPriceResponseMessage"><wsdl:part name="part1" element="ns:getPriceResponse" /></wsdl:message><wsdl:message name="updateMessage"><wsdl:part name="part1" element="ns:update" /></wsdl:message><wsdl:portType name="StockQuoteServicePortType"><wsdl:operation name="getPrice"><wsdl:input message="axis2:getPriceMessage" /><wsdl:output message="axis2:getPriceResponseMessage" /></wsdl:operation><wsdl:operation name="update"><wsdl:input message="axis2:updateMessage" /></wsdl:operation></wsdl:portType><wsdl:binding name="StockQuoteServiceSOAP11Binding" type="axis2:StockQuoteServicePortType"><soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document" /><wsdl:operation name="getPrice"><soap:operation soapAction="urn:getPrice" style="document" /><wsdl:input><soap:body use="literal" namespace="http://quickstart.samples/" /></wsdl:input><wsdl:output><soap:body use="literal" namespace="http://quickstart.samples/" /></wsdl:output></wsdl:operation><wsdl:operation name="update"><soap:operation soapAction="urn:update" style="document" /><wsdl:input><soap:body use="literal" namespace="http://quickstart.samples/" /></wsdl:input></wsdl:operation></wsdl:binding><wsdl:binding name="StockQuoteServiceSOAP12Binding" type="axis2:StockQuoteServicePortType"><soap12:binding transport="http://schemas.xmlsoap.org/soap/http" style="document" /><wsdl:operation name="getPrice"><soap12:operation soapAction="urn:getPrice" style="document" /><wsdl:input><soap12:body use="literal" namespace="http://quickstart.samples/" /></wsdl:input><wsdl:output><soap12:body use="literal" namespace="http://quickstart.samples/" /></wsdl:output></wsdl:operation><wsdl:operation name="update"><soap12:operation soapAction="urn:update" style="document" /><wsdl:input><soap12:body use="literal" namespace="http://quickstart.samples/" /></wsdl:input></wsdl:operation></wsdl:binding><wsdl:service name="StockQuoteServiceOne"><wsdl:port name="StockQuoteServiceSOAP11port" binding="axis2:StockQuoteServiceSOAP11Binding"><soap:address location="http://localhost:8080/axis2/services/StockQuoteService" /></wsdl:port></wsdl:service></wsdl:definitions>

--- a/src/test/resources/axis1/multiple-files/StockQuoteServiceTwo.wsdl
+++ b/src/test/resources/axis1/multiple-files/StockQuoteServiceTwo.wsdl
@@ -1,0 +1,43 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements. See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership. The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<wsdl:definitions xmlns:axis2="http://quickstart.samples/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:ns="http://quickstart.samples/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://quickstart.samples/"><wsdl:types><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://quickstart.samples/xsd">
+<xs:element name="getPrice">
+<xs:complexType>
+<xs:sequence>
+<xs:element name="symbol" nillable="true" type="xs:string" />
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+<xs:element name="getPriceResponse">
+<xs:complexType>
+<xs:sequence>
+<xs:element name="return" nillable="true" type="xs:double" />
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+<xs:element name="update">
+<xs:complexType>
+<xs:sequence>
+<xs:element name="symbol" nillable="true" type="xs:string" />
+<xs:element name="price" nillable="true" type="xs:double" />
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+</xs:schema></wsdl:types><wsdl:message name="getPriceMessage"><wsdl:part name="part1" element="ns:getPrice" /></wsdl:message><wsdl:message name="getPriceResponseMessage"><wsdl:part name="part1" element="ns:getPriceResponse" /></wsdl:message><wsdl:message name="updateMessage"><wsdl:part name="part1" element="ns:update" /></wsdl:message><wsdl:portType name="StockQuoteServicePortType"><wsdl:operation name="getPrice"><wsdl:input message="axis2:getPriceMessage" /><wsdl:output message="axis2:getPriceResponseMessage" /></wsdl:operation><wsdl:operation name="update"><wsdl:input message="axis2:updateMessage" /></wsdl:operation></wsdl:portType><wsdl:binding name="StockQuoteServiceSOAP11Binding" type="axis2:StockQuoteServicePortType"><soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document" /><wsdl:operation name="getPrice"><soap:operation soapAction="urn:getPrice" style="document" /><wsdl:input><soap:body use="literal" namespace="http://quickstart.samples/" /></wsdl:input><wsdl:output><soap:body use="literal" namespace="http://quickstart.samples/" /></wsdl:output></wsdl:operation><wsdl:operation name="update"><soap:operation soapAction="urn:update" style="document" /><wsdl:input><soap:body use="literal" namespace="http://quickstart.samples/" /></wsdl:input></wsdl:operation></wsdl:binding><wsdl:binding name="StockQuoteServiceSOAP12Binding" type="axis2:StockQuoteServicePortType"><soap12:binding transport="http://schemas.xmlsoap.org/soap/http" style="document" /><wsdl:operation name="getPrice"><soap12:operation soapAction="urn:getPrice" style="document" /><wsdl:input><soap12:body use="literal" namespace="http://quickstart.samples/" /></wsdl:input><wsdl:output><soap12:body use="literal" namespace="http://quickstart.samples/" /></wsdl:output></wsdl:operation><wsdl:operation name="update"><soap12:operation soapAction="urn:update" style="document" /><wsdl:input><soap12:body use="literal" namespace="http://quickstart.samples/" /></wsdl:input></wsdl:operation></wsdl:binding><wsdl:service name="StockQuoteServiceTwo"><wsdl:port name="StockQuoteServiceSOAP11port" binding="axis2:StockQuoteServiceSOAP11Binding"><soap:address location="http://localhost:8080/axis2/services/StockQuoteService" /></wsdl:port></wsdl:service></wsdl:definitions>

--- a/src/test/resources/axis2/multiple-files/StockQuoteServiceOne.wsdl
+++ b/src/test/resources/axis2/multiple-files/StockQuoteServiceOne.wsdl
@@ -1,0 +1,43 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements. See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership. The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<wsdl:definitions xmlns:axis2="http://quickstart.samples/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:ns="http://quickstart.samples/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://quickstart.samples/"><wsdl:types><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://quickstart.samples/xsd">
+<xs:element name="getPrice">
+<xs:complexType>
+<xs:sequence>
+<xs:element name="symbol" nillable="true" type="xs:string" />
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+<xs:element name="getPriceResponse">
+<xs:complexType>
+<xs:sequence>
+<xs:element name="return" nillable="true" type="xs:double" />
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+<xs:element name="update">
+<xs:complexType>
+<xs:sequence>
+<xs:element name="symbol" nillable="true" type="xs:string" />
+<xs:element name="price" nillable="true" type="xs:double" />
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+</xs:schema></wsdl:types><wsdl:message name="getPriceMessage"><wsdl:part name="part1" element="ns:getPrice" /></wsdl:message><wsdl:message name="getPriceResponseMessage"><wsdl:part name="part1" element="ns:getPriceResponse" /></wsdl:message><wsdl:message name="updateMessage"><wsdl:part name="part1" element="ns:update" /></wsdl:message><wsdl:portType name="StockQuoteServicePortType"><wsdl:operation name="getPrice"><wsdl:input message="axis2:getPriceMessage" /><wsdl:output message="axis2:getPriceResponseMessage" /></wsdl:operation><wsdl:operation name="update"><wsdl:input message="axis2:updateMessage" /></wsdl:operation></wsdl:portType><wsdl:binding name="StockQuoteServiceSOAP11Binding" type="axis2:StockQuoteServicePortType"><soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document" /><wsdl:operation name="getPrice"><soap:operation soapAction="urn:getPrice" style="document" /><wsdl:input><soap:body use="literal" namespace="http://quickstart.samples/" /></wsdl:input><wsdl:output><soap:body use="literal" namespace="http://quickstart.samples/" /></wsdl:output></wsdl:operation><wsdl:operation name="update"><soap:operation soapAction="urn:update" style="document" /><wsdl:input><soap:body use="literal" namespace="http://quickstart.samples/" /></wsdl:input></wsdl:operation></wsdl:binding><wsdl:binding name="StockQuoteServiceSOAP12Binding" type="axis2:StockQuoteServicePortType"><soap12:binding transport="http://schemas.xmlsoap.org/soap/http" style="document" /><wsdl:operation name="getPrice"><soap12:operation soapAction="urn:getPrice" style="document" /><wsdl:input><soap12:body use="literal" namespace="http://quickstart.samples/" /></wsdl:input><wsdl:output><soap12:body use="literal" namespace="http://quickstart.samples/" /></wsdl:output></wsdl:operation><wsdl:operation name="update"><soap12:operation soapAction="urn:update" style="document" /><wsdl:input><soap12:body use="literal" namespace="http://quickstart.samples/" /></wsdl:input></wsdl:operation></wsdl:binding><wsdl:service name="StockQuoteServiceOne"><wsdl:port name="StockQuoteServiceSOAP11port" binding="axis2:StockQuoteServiceSOAP11Binding"><soap:address location="http://localhost:8080/axis2/services/StockQuoteService" /></wsdl:port></wsdl:service></wsdl:definitions>

--- a/src/test/resources/axis2/multiple-files/StockQuoteServiceTwo.wsdl
+++ b/src/test/resources/axis2/multiple-files/StockQuoteServiceTwo.wsdl
@@ -1,0 +1,43 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements. See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership. The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<wsdl:definitions xmlns:axis2="http://quickstart.samples/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:http="http://schemas.xmlsoap.org/wsdl/http/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:ns="http://quickstart.samples/xsd" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://quickstart.samples/"><wsdl:types><xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="qualified" elementFormDefault="qualified" targetNamespace="http://quickstart.samples/xsd">
+<xs:element name="getPrice">
+<xs:complexType>
+<xs:sequence>
+<xs:element name="symbol" nillable="true" type="xs:string" />
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+<xs:element name="getPriceResponse">
+<xs:complexType>
+<xs:sequence>
+<xs:element name="return" nillable="true" type="xs:double" />
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+<xs:element name="update">
+<xs:complexType>
+<xs:sequence>
+<xs:element name="symbol" nillable="true" type="xs:string" />
+<xs:element name="price" nillable="true" type="xs:double" />
+</xs:sequence>
+</xs:complexType>
+</xs:element>
+</xs:schema></wsdl:types><wsdl:message name="getPriceMessage"><wsdl:part name="part1" element="ns:getPrice" /></wsdl:message><wsdl:message name="getPriceResponseMessage"><wsdl:part name="part1" element="ns:getPriceResponse" /></wsdl:message><wsdl:message name="updateMessage"><wsdl:part name="part1" element="ns:update" /></wsdl:message><wsdl:portType name="StockQuoteServicePortType"><wsdl:operation name="getPrice"><wsdl:input message="axis2:getPriceMessage" /><wsdl:output message="axis2:getPriceResponseMessage" /></wsdl:operation><wsdl:operation name="update"><wsdl:input message="axis2:updateMessage" /></wsdl:operation></wsdl:portType><wsdl:binding name="StockQuoteServiceSOAP11Binding" type="axis2:StockQuoteServicePortType"><soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document" /><wsdl:operation name="getPrice"><soap:operation soapAction="urn:getPrice" style="document" /><wsdl:input><soap:body use="literal" namespace="http://quickstart.samples/" /></wsdl:input><wsdl:output><soap:body use="literal" namespace="http://quickstart.samples/" /></wsdl:output></wsdl:operation><wsdl:operation name="update"><soap:operation soapAction="urn:update" style="document" /><wsdl:input><soap:body use="literal" namespace="http://quickstart.samples/" /></wsdl:input></wsdl:operation></wsdl:binding><wsdl:binding name="StockQuoteServiceSOAP12Binding" type="axis2:StockQuoteServicePortType"><soap12:binding transport="http://schemas.xmlsoap.org/soap/http" style="document" /><wsdl:operation name="getPrice"><soap12:operation soapAction="urn:getPrice" style="document" /><wsdl:input><soap12:body use="literal" namespace="http://quickstart.samples/" /></wsdl:input><wsdl:output><soap12:body use="literal" namespace="http://quickstart.samples/" /></wsdl:output></wsdl:operation><wsdl:operation name="update"><soap12:operation soapAction="urn:update" style="document" /><wsdl:input><soap12:body use="literal" namespace="http://quickstart.samples/" /></wsdl:input></wsdl:operation></wsdl:binding><wsdl:service name="StockQuoteServiceTwo"><wsdl:port name="StockQuoteServiceSOAP11port" binding="axis2:StockQuoteServiceSOAP11Binding"><soap:address location="http://localhost:8080/axis2/services/StockQuoteService" /></wsdl:port></wsdl:service></wsdl:definitions>


### PR DESCRIPTION
Hello

I have added some modifications to your plugin in order to be able to use it with a folder that contains several wsdl files. This folder is passed to the plugin through the wsdlFile parameter. The files processed by the plugin make use of the gpars plugin to process the wsdl files in parallel
I have added two tests to test this new functionality that use copies of the existing resources.

Please let me know what do you think about this modification and include it if you think it's helpfull.
Regards