### PR TITLE
Configure build-scan plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,9 @@ import java.util.*
  * limitations under the License.
  */
 plugins {
+    // build performance
+    id("com.gradle.build-scan") version "2.2.1"
+
     // project plugins
     `java-gradle-plugin`
     groovy
@@ -53,6 +56,11 @@ plugins {
 
     // plugin for publishing to jcenter
     id("com.jfrog.bintray") version "1.8.4"
+}
+
+buildScan {
+    termsOfServiceUrl   = "https://gradle.com/terms-of-service"
+    termsOfServiceAgree = "yes"
 }
 
 scm {

--- a/buildTravis.sh
+++ b/buildTravis.sh
@@ -7,17 +7,17 @@ export GRADLE_OPTS="-Dorg.gradle.daemon=true"
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
     if [ "$TRAVIS_TAG" == "" ]; then
         echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH'] and without Tag'
-        ./gradlew test build -s
+        ./gradlew test build -s --scan
     else
         echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH'] Tag ['$TRAVIS_TAG']'
-        ./gradlew -PrunOnCI=true test build :bintrayUpload :publishPlugins -s
+        ./gradlew -PrunOnCI=true test build :bintrayUpload :publishPlugins -s --scan
     fi
 else
     if [ "$TRAVIS_TAG" == "" ]; then
         echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH'] and without Tag'
-        ./gradlew test build -s
+        ./gradlew test build -s --scan
     else
         echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH'] Tag ['$TRAVIS_TAG']'
-        ./gradlew -PrunOnCI=true test build :bintrayUpload :publishPlugins -s
+        ./gradlew -PrunOnCI=true test build :bintrayUpload :publishPlugins -s --scan
     fi
 fi


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.