### PR TITLE
Update README.asciidoc

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -191,7 +191,7 @@ WSDL2Java Parameter: -W, --noWrapped
 | *serverSide* | `boolean` | `false` | Emit the server-side bindings for the web service. +
 WSDL2Java Parameter: -s, --server-side
 | *skeletonDeploy* | `String` | `""` | If this property is defined, the parameter is added. If deploy skeleton (true) or implementation (false) in deploy.wsdd. +
-Default is an empty string. Assumes server-side="true". WSDL2Java Parameter: -S, --skeletonDeploy <true|false>
+Default is an empty string. Assumes server-side="true". WSDL2Java Parameter: -S, --skeletonDeploy <true\|false>
 | *deployScope* | `String` | | Add scope to deploy.wsdd: +
 - APPLICATION -> "Application", +
 - REQUEST     -> "Request", or +


### PR DESCRIPTION
escape pipe character to avoid split the line premature